### PR TITLE
Fix Rconv duration indexing and add test

### DIFF
--- a/R/evaluate-helpers.R
+++ b/R/evaluate-helpers.R
@@ -145,9 +145,20 @@ eval_Rconv <- function(p, ...) {
   
   # Proceed with R convolution using stats::convolve
   delta <- numeric(length(p$fine_grid))
-  onset_indices <- round((p$valid_ons - p$fine_grid[1]) / p$precision) + 1
+  onset_indices <- floor((p$valid_ons - p$fine_grid[1]) / p$precision) + 1
   valid_onset_indices <- onset_indices >= 1 & onset_indices <= length(p$fine_grid)
-  delta[onset_indices[valid_onset_indices]] <- p$valid_amp[valid_onset_indices]
+
+  if (length(p$valid_durs) > 0) {
+    dur_len <- floor(p$valid_durs[1] / p$precision)
+  } else {
+    dur_len <- 0
+  }
+
+  for (i in which(valid_onset_indices)) {
+    start_idx <- onset_indices[i]
+    end_idx <- min(start_idx + dur_len, length(p$fine_grid))
+    delta[start_idx:end_idx] <- delta[start_idx:end_idx] + p$valid_amp[i]
+  }
   
   samhrf <- p$hrf_fine_matrix # Already evaluated and potentially memoized
   nb <- p$nb

--- a/tests/testthat/test_regressor.R
+++ b/tests/testthat/test_regressor.R
@@ -75,6 +75,16 @@ test_that("evaluate.Reg computes convolution correctly", {
 })
 
 
+test_that("Rconv handles non-zero constant durations", {
+  reg <- regressor(onsets = c(0, 2), duration = 2, amplitude = c(1, 1),
+                   hrf = BOX_HRF, span = 1)
+  grid <- 0:6
+  res_conv <- evaluate(reg, grid, method = "conv", precision = 1)
+  res_rconv <- evaluate(reg, grid, method = "Rconv", precision = 1)
+  expect_equal(res_rconv, res_conv)
+})
+
+
 test_that("unsorted grid triggers warning and sorted output", {
   reg <- regressor(onsets = 0, hrf = BOX_HRF, span = 1)
   expect_warning(out <- evaluate(reg, c(3, 0, 1), method = "conv", precision = 1))


### PR DESCRIPTION
## Summary
- respect constant event durations in `eval_Rconv`
- compute onset indices using `floor`
- regression test for `Rconv` with non-zero constant durations

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cd47e7888832d901e279662141599