### PR TITLE
Fix normalise_hrf with sweep

### DIFF
--- a/R/hrf_decorators.R
+++ b/R/hrf_decorators.R
@@ -185,15 +185,12 @@ normalise_hrf <- function(hrf) {
         res <- res / peak_val
       }
     } else if (is.matrix(res)) {
-      # Normalise each basis column independently
-      res <- apply(res, 2, function(basis_col) {
-        peak_val <- max(abs(basis_col), na.rm = TRUE)
-        if (!is.na(peak_val) && peak_val != 0) {
-          basis_col / peak_val
-        } else {
-          basis_col
-        }
+      # Normalise each basis column independently while preserving matrix shape
+      peaks <- apply(res, 2, function(basis_col) {
+        max(abs(basis_col), na.rm = TRUE)
       })
+      peaks_safe <- ifelse(is.na(peaks) | peaks == 0, 1, peaks)
+      res <- sweep(res, 2, peaks_safe, "/")
     }
     # If it's not numeric or matrix (e.g., NULL or error result), return as is
     return(res)

--- a/tests/testthat/test_hrf.R
+++ b/tests/testthat/test_hrf.R
@@ -432,6 +432,13 @@ test_that("normalise_hrf correctly normalises an HRF object", {
   expect_equal(max(abs(result_norm_spmg2[,2])), 1)
 })
 
+test_that("normalised multi-basis HRF evaluated at single point returns matrix", {
+  norm_spmg2 <- normalise_hrf(HRF_SPMG2)
+  single_res <- norm_spmg2(0)
+  expect_true(is.matrix(single_res))
+  expect_equal(dim(single_res), c(1, nbasis(norm_spmg2)))
+})
+
 test_that("gen_hrf correctly sets nbasis for function inputs", {
   # Single basis functions
   hrf_g <- gen_hrf(hrf_gaussian)


### PR DESCRIPTION
## Summary
- use `sweep()` in `normalise_hrf()` so single timepoint evaluations keep matrix shape
- test that single point evaluations of normalised multi-basis HRFs return a matrix

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_683cd53e6d48832dab36d0610a43d8d0