### PR TITLE
Fix nbasis handling for function HRFs

### DIFF
--- a/R/hrf-formula.R
+++ b/R/hrf-formula.R
@@ -18,7 +18,10 @@ make_hrf <- function(basis, lag, nbasis=1) {
     final_hrf <- gen_hrf(basis, lag = lag)
     
   } else if (is.function(basis)) {
-    # If it's a raw function, gen_hrf will handle conversion via as_hrf and apply lag
+    # If a plain function is provided, explicitly convert it to an HRF so that
+    # the number of basis functions is set correctly before applying any
+    # decorators.
+    basis <- as_hrf(basis, nbasis = nbasis)
     final_hrf <- gen_hrf(basis, lag = lag)
 
   } else {


### PR DESCRIPTION
## Summary
- ensure `make_hrf` converts function basis inputs using `as_hrf` so nbasis is set

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cd555a460832dae5b6d0864b1e2b4