### PR TITLE
Simplify HRF retrieval in make_hrf

### DIFF
--- a/R/hrf-formula.R
+++ b/R/hrf-formula.R
@@ -6,12 +6,8 @@ make_hrf <- function(basis, lag, nbasis=1) {
   }
   
   if (is.character(basis)) {
-    # Resolve character name to a base HRF object or function using getHRF
-    # Note: getHRF itself might need simplification later (Ticket 12)
-    # but currently it calls gen_hrf internally for most types.
-    base_hrf_obj <- getHRF(basis, nbasis=nbasis, lag=0)
-    # Apply lag using gen_hrf
-    final_hrf <- gen_hrf(base_hrf_obj, lag = lag)
+    # Directly retrieve the HRF object with lag applied
+    final_hrf <- getHRF(basis, nbasis = nbasis, lag = lag)
 
   } else if (inherits(basis, "HRF")) {
     # If it's already an HRF object, apply lag using gen_hrf


### PR DESCRIPTION
## Summary
- simplify the character branch of `make_hrf`
- directly call `getHRF` with lag applied

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cd559126c832dba97f53fd8ad8556