### PR TITLE
Enhance error message for invalid basis type

### DIFF
--- a/R/hrf-formula.R
+++ b/R/hrf-formula.R
@@ -22,7 +22,10 @@ make_hrf <- function(basis, lag, nbasis=1) {
     final_hrf <- gen_hrf(basis, lag = lag)
 
   } else {
-    stop("invalid basis function: must be 1) character string indicating hrf type, e.g. 'gamma' 2) a function or 3) an object of class 'HRF': ", basis)
+    stop(sprintf(
+      "invalid basis function '%s' of class %s: must be 1) character string indicating hrf type, e.g. 'gamma', 2) a function or 3) an object of class 'HRF'",
+      deparse(substitute(basis)), paste(class(basis), collapse = ", ")
+    ))
   }
   
   return(final_hrf)


### PR DESCRIPTION
## Summary
- refine `make_hrf` error message when basis is invalid

## Testing
- `R` command not found, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_683cd55bf940832da85b166b07e7f15e