### PR TITLE
Update hrf_library with extras handling

### DIFF
--- a/R/hrf.R
+++ b/R/hrf.R
@@ -228,16 +228,11 @@ gen_hrf_set <- function(...) {
 #' @importFrom purrr pmap partial
 #' @export
 hrf_library <- function(fun, pgrid, ...) {
+  extras <- list(...)
   # Ensure fun returns an HRF object
   hrf_list <- purrr::pmap(pgrid, function(...) {
       params <- list(...)
-      # Assuming 'fun' is designed to take these params and return an HRF
-      # If fun itself is just a base function, we need to wrap it
-      # Let's assume fun already produces an HRF or can be wrapped by as_hrf
-      # This part might need adjustment based on typical usage of 'fun'
-      do.call(fun, c(params, list(...))) # Pass original dots as well?
-      # Safest might be if 'fun' is expected to return an HRF object directly
-      # Example: fun = function(lag) HRF_SPMG1 |> lag_hrf(lag)
+      do.call(fun, c(params, extras))
   })
   # Bind the generated HRFs
   do.call(bind_basis, hrf_list)

--- a/tests/testthat/test_hrf_library.R
+++ b/tests/testthat/test_hrf_library.R
@@ -1,0 +1,25 @@
+library(testthat)
+
+# simple generator that records scale
+make_gauss <- function(mean=0, sd=1, scale=1) {
+  as_hrf(function(t) scale * dnorm(t, mean, sd),
+         name = paste0("gauss_", mean),
+         nbasis = 1L)
+}
+
+
+test_that("hrf_library forwards extra arguments", {
+  pgrid <- data.frame(mean = c(0, 2), sd = c(1, 1))
+  lib <- hrf_library(make_gauss, pgrid, scale = 2)
+  expect_s3_class(lib, "HRF")
+  expect_equal(nbasis(lib), 2)
+  t <- c(0, 1)
+  expected <- cbind(2 * dnorm(t, 0, 1), 2 * dnorm(t, 2, 1))
+  expect_equal(lib(t), expected)
+})
+
+
+test_that("duplicate parameter names cause an error", {
+  pgrid <- data.frame(mean = 0, sd = 1, scale = 1)
+  expect_error(hrf_library(make_gauss, pgrid, scale = 2))
+})


### PR DESCRIPTION
## Summary
- update `hrf_library()` to cache `extras` and forward them with `do.call`
- add regression tests for `hrf_library` extras behaviour and duplicate arguments

## Testing
- `Rscript -e "library(testthat); test_dir('tests/testthat')"` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cd5648214832d969b846d16b69a70