### PR TITLE
Fix normalization logic and add regression test

### DIFF
--- a/R/hrf.R
+++ b/R/hrf.R
@@ -848,10 +848,9 @@ evaluate.HRF <- function(x, grid, amplitude = 1, duration = 0,
   # Apply normalization if requested, handling matrix/vector case
   if (normalize) {
       if (is.matrix(out)) {
-          apply(out, 2, function(col) {
-              peak_val <- max(abs(col), na.rm = TRUE)
-              if (!is.na(peak_val) && peak_val != 0) col / peak_val else col
-          })
+          peaks <- apply(out, 2, function(col) max(abs(col), na.rm = TRUE))
+          peaks[peaks == 0 | is.na(peaks)] <- 1
+          out <- sweep(out, 2, peaks, "/")
       } else {
           peak_val <- max(abs(out), na.rm = TRUE)
           if (!is.na(peak_val) && peak_val != 0) out / peak_val else out

--- a/tests/testthat/test_hrf.R
+++ b/tests/testthat/test_hrf.R
@@ -462,3 +462,14 @@ test_that("gen_hrf correctly sets nbasis for function inputs", {
   hrf_tent7 <- gen_hrf(hrf_bspline, N = 7, degree = 1)
   expect_equal(nbasis(hrf_tent7), 7)
 })
+
+test_that("normalize in evaluate.HRF preserves matrix dimensions", {
+  grid <- seq(0, 2, by = 1)
+  res <- evaluate(HRF_SPMG2, grid, normalize = TRUE)
+  expect_true(is.matrix(res))
+  expect_equal(dim(res), c(length(grid), nbasis(HRF_SPMG2)))
+
+  single <- evaluate(HRF_SPMG2, 0, normalize = TRUE)
+  expect_true(is.matrix(single))
+  expect_equal(dim(single), c(1L, nbasis(HRF_SPMG2)))
+})


### PR DESCRIPTION
## Summary
- fix matrix normalization code in `evaluate.HRF`
- add tests to ensure matrix dimensions are preserved after normalization

## Testing
- `R CMD check` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683cd56579cc832d84e25bcf972e80f1