### PR TITLE
Add input validation for Reg constructor

### DIFF
--- a/R/reg-constructor.R
+++ b/R/reg-constructor.R
@@ -20,11 +20,25 @@ Reg <- function(onsets, hrf=HRF_SPMG1, duration=0, amplitude=1, span=40, summate
   if (length(onsets) == 1 && is.na(onsets[1])) {
       onsets <- numeric(0)
   }
+
+  # Validate converted inputs for finiteness/NA
+  if (anyNA(onsets) || any(!is.finite(onsets))) {
+      stop("`onsets` must contain finite numeric values.", call. = FALSE)
+  }
+  if (anyNA(duration) || any(!is.finite(duration))) {
+      stop("`duration` must contain finite numeric values.", call. = FALSE)
+  }
+  if (anyNA(amplitude) || any(!is.finite(amplitude))) {
+      stop("`amplitude` must contain finite numeric values.", call. = FALSE)
+  }
+  if (is.na(span_arg) || !is.finite(span_arg) || span_arg <= 0) {
+      stop("`span` must be a positive, finite number.", call. = FALSE)
+  }
   n_onsets <- length(onsets)
-  
+
   # Check for invalid onsets *before* recycling other args
-  if (any(onsets < 0 | is.na(onsets))) {
-      stop("`onsets` must be non-negative and non-NA.", call. = FALSE)
+  if (any(onsets < 0)) {
+      stop("`onsets` must be non-negative.", call. = FALSE)
   }
   
   # Recycle/Validate inputs *before* filtering
@@ -34,7 +48,6 @@ Reg <- function(onsets, hrf=HRF_SPMG1, duration=0, amplitude=1, span=40, summate
   
   # Check for invalid inputs early
   if (any(duration < 0, na.rm = TRUE)) stop("`duration` cannot be negative.")
-  if (span_arg <= 0) stop("`span` must be positive.")
   
   # Filter events based on non-zero and non-NA amplitude (Ticket B-3)
   if (n_onsets > 0) { 
@@ -113,7 +126,7 @@ Reg <- function(onsets, hrf=HRF_SPMG1, duration=0, amplitude=1, span=40, summate
 #' efficient storage. The resulting object can be evaluated at specific time points 
 #' using the `evaluate()` function.
 #' 
-#' Events with an amplitude of 0 or NA are automatically filtered out.
+#' Events with an amplitude of 0 are automatically filtered out.
 #' 
 #' @return An S3 object of class `Reg` and `list` 
 #'   containing processed event information and the HRF specification.

--- a/man/regressor.Rd
+++ b/man/regressor.Rd
@@ -52,5 +52,5 @@ Internally, it utilizes the `Reg()` constructor which performs validation and
 efficient storage. The resulting object can be evaluated at specific time points 
 using the `evaluate()` function.
 
-Events with an amplitude of 0 or NA are automatically filtered out.
+Events with an amplitude of 0 are automatically filtered out.
 }

--- a/tests/testthat/test_regressor.R
+++ b/tests/testthat/test_regressor.R
@@ -28,11 +28,11 @@ test_that("regressor constructs valid Reg objects", {
 })
 
 
-test_that("events with zero or NA amplitude are filtered", {
-  reg <- regressor(onsets = c(1, 2, 3), amplitude = c(1, 0, NA))
-  expect_equal(reg$onsets, 1)
-  expect_equal(reg$duration, 0)
-  expect_equal(reg$amplitude, 1)
+test_that("events with zero amplitude are filtered", {
+  reg <- regressor(onsets = c(1, 2, 3), amplitude = c(1, 0, 2))
+  expect_equal(reg$onsets, c(1, 3))
+  expect_equal(reg$duration, c(0, 0))
+  expect_equal(reg$amplitude, c(1, 2))
   expect_false(attr(reg, "filtered_all"))
 
   reg_empty <- regressor(onsets = c(1, 2), amplitude = c(0, 0))
@@ -40,11 +40,22 @@ test_that("events with zero or NA amplitude are filtered", {
   expect_true(attr(reg_empty, "filtered_all"))
 })
 
+test_that("NA inputs trigger errors", {
+  expect_error(regressor(onsets = NA_real_, duration = 1), "onsets")
+  expect_error(regressor(onsets = 1, duration = NA_real_), "duration")
+  expect_error(regressor(onsets = 1, amplitude = NA_real_), "amplitude")
+  expect_error(regressor(onsets = 1, span = NA_real_), "span")
+})
+
 
 test_that("invalid inputs are rejected", {
   expect_error(regressor(onsets = c(-1, 1)), "onsets")
   expect_error(regressor(onsets = 1, duration = -2), "duration")
   expect_error(regressor(onsets = 1, span = 0), "span")
+  expect_error(regressor(onsets = c(1, Inf)), "onsets")
+  expect_error(regressor(onsets = 1, duration = Inf), "duration")
+  expect_error(regressor(onsets = 1, amplitude = Inf), "amplitude")
+  expect_error(regressor(onsets = 1, span = Inf), "span")
 })
 
 


### PR DESCRIPTION
## Summary
- validate converted arguments in `Reg()`
- drop NA amplitude support in documentation
- extend regressor tests for new validation rules

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cd57093fc832daec0ba53f6f4cc0c