### PR TITLE
Update docs and remove ticket comments

### DIFF
--- a/R/evaluate-helpers.R
+++ b/R/evaluate-helpers.R
@@ -60,7 +60,7 @@ prep_reg_inputs <- function(x, grid, precision) {
     return(list(nb = nb, grid = grid, valid_ons = numeric(0)))
   }
   
-  # Prepare/Memoize finely sampled HRF (Efficiency 2.1 / Ticket D-1)
+  # Prepare/Memoize finely sampled HRF for efficient evaluation
   hrf_fine_matrix <- .memo_hrf(x$hrf, hrf_span, precision)
   
   # Prepare fine grid (needed for Rconv/loop interpolation)

--- a/R/hrf-formula.R
+++ b/R/hrf-formula.R
@@ -7,8 +7,8 @@ make_hrf <- function(basis, lag, nbasis=1) {
   
   if (is.character(basis)) {
     # Resolve character name to a base HRF object or function using getHRF
-    # Note: getHRF itself might need simplification later (Ticket 12)
-    # but currently it calls gen_hrf internally for most types.
+    # Note: getHRF itself might need simplification later; it currently calls
+    # gen_hrf internally for most types.
     base_hrf_obj <- getHRF(basis, nbasis=nbasis, lag=0)
     # Apply lag using gen_hrf
     final_hrf <- gen_hrf(base_hrf_obj, lag = lag)

--- a/R/reg-constructor.R
+++ b/R/reg-constructor.R
@@ -6,6 +6,8 @@
 #'   * `amplitude`: Numeric vector of event amplitudes/scaling factors.
 #'   * `span`: Numeric scalar indicating the HRF span (seconds).
 #'   * `summate`: Logical indicating if overlapping HRF responses should summate.
+#'   * `filtered_all`: Logical attribute set to `TRUE` when all events were
+#'     removed due to zero or `NA` amplitudes.
 #' @importFrom assertthat assert_that
 Reg <- function(onsets, hrf=HRF_SPMG1, duration=0, amplitude=1, span=40, summate=TRUE) {
   
@@ -36,7 +38,7 @@ Reg <- function(onsets, hrf=HRF_SPMG1, duration=0, amplitude=1, span=40, summate
   if (any(duration < 0, na.rm = TRUE)) stop("`duration` cannot be negative.")
   if (span_arg <= 0) stop("`span` must be positive.")
   
-  # Filter events based on non-zero and non-NA amplitude (Ticket B-3)
+  # Filter events based on non-zero and non-NA amplitude
   if (n_onsets > 0) { 
       keep_indices <- which(amplitude != 0 & !is.na(amplitude))
       # Store whether filtering occurred
@@ -55,8 +57,7 @@ Reg <- function(onsets, hrf=HRF_SPMG1, duration=0, amplitude=1, span=40, summate
       filtered_all <- TRUE # If input was empty, effectively all are filtered
   }
   
-  # Ensure HRF is a valid HRF object using make_hrf 
-  # Explicitly namespace internal function call (Ticket G-3)
+  # Ensure HRF is a valid HRF object using make_hrf
   hrf  <- make_hrf(hrf, lag = 0) 
   assert_that(inherits(hrf, "HRF"), msg = "Invalid 'hrf' provided or generated.")
   
@@ -115,8 +116,10 @@ Reg <- function(onsets, hrf=HRF_SPMG1, duration=0, amplitude=1, span=40, summate
 #' 
 #' Events with an amplitude of 0 or NA are automatically filtered out.
 #' 
-#' @return An S3 object of class `Reg` and `list` 
-#'   containing processed event information and the HRF specification.
+#' @return An S3 object of class `Reg` and `list`
+#'   containing processed event information and the HRF specification. The
+#'   object includes a `filtered_all` attribute indicating whether all events
+#'   were removed due to zero or `NA` amplitudes.
 #' @importFrom assertthat assert_that
 #' @export
 regressor <- Reg # Assign Reg directly to regressor

--- a/man/regressor.Rd
+++ b/man/regressor.Rd
@@ -38,8 +38,10 @@ with the duration of sustained events (via internal convolution/summation). If `
 the response reflects the peak HRF reached during the event duration.}
 }
 \value{
-An S3 object of class `Reg` and `list` 
-  containing processed event information and the HRF specification.
+An S3 object of class `Reg` and `list`
+  containing processed event information and the HRF specification. The
+  object includes a \code{filtered_all} attribute indicating whether all
+  events were removed due to zero or \code{NA} amplitudes.
 }
 \description{
 Creates an object representing event-related regressors for fMRI modeling.


### PR DESCRIPTION
## Summary
- purge obsolete `Ticket` references in source code
- document `filtered_all` attribute in Reg constructor and regressor docs

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cd5771314832db15b1116a9c92ef5