### PR TITLE
Fix evaluate.Reg zero event sparse handling

### DIFF
--- a/R/reg-methods.R
+++ b/R/reg-methods.R
@@ -34,7 +34,15 @@ evaluate.Reg <- function(x, grid, precision=.33, method=c("conv", "fft", "Rconv"
   
   # Check if prep_reg_inputs indicated no relevant events
   if (length(prep_data$valid_ons) == 0) {
-    return(matrix(0, length(grid), prep_data$nb)) 
+    zero_res <- if (prep_data$nb == 1) {
+      rep(0, length(grid))
+    } else {
+      matrix(0, nrow = length(grid), ncol = prep_data$nb)
+    }
+    if (sparse) {
+      zero_res <- Matrix::Matrix(zero_res, sparse = TRUE)
+    }
+    return(zero_res)
   }
   
   # --- Method Dispatch to Internal Engines ---
@@ -62,11 +70,7 @@ evaluate.Reg <- function(x, grid, precision=.33, method=c("conv", "fft", "Rconv"
   
   # Convert to sparse matrix if requested
   if (sparse) {
-    if (is.vector(final_result)) {
-      return(Matrix::Matrix(final_result, sparse=TRUE))
-    } else {
-      return(Matrix::Matrix(final_result, sparse=TRUE))
-    }
+    return(Matrix::Matrix(final_result, sparse = TRUE))
   } else {
     return(final_result)
   }


### PR DESCRIPTION
## Summary
- handle sparse option when no valid events are present in evaluate.Reg
- simplify sparse conversion

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_683cd580366c832db320a7402b239d2f