### PR TITLE
Improve shift.Reg argument handling

### DIFF
--- a/R/reg-methods.R
+++ b/R/reg-methods.R
@@ -78,14 +78,21 @@ evaluate.Reg <- function(x, grid, precision=.33, method=c("conv", "fft", "Rconv"
 #' @export
 #' @importFrom assertthat assert_that
 shift.Reg <- function(x, shift_amount, ...) {
-  if (!inherits(x, "Reg")) {
-    # This check might be redundant if S3 dispatch works, but good safety
-    stop("Input 'x' must inherit from class 'Reg'")
+  dots <- list(...)
+
+  if (missing(shift_amount) && "offset" %in% names(dots)) {
+    shift_amount <- dots$offset
   }
 
-  if (!is.numeric(shift_amount) || length(shift_amount) != 1) {
-    stop("`shift_amount` must be a single numeric value")
+  assert_that(inherits(x, "Reg"),
+              msg = "Input 'x' must inherit from class 'Reg'")
+
+  if (missing(shift_amount)) {
+    stop("Must supply `shift_amount` or `offset`.", call. = FALSE)
   }
+
+  assert_that(is.numeric(shift_amount) && length(shift_amount) == 1,
+              msg = "`shift_amount` must be a single numeric value")
 
   # Handle empty regressor case
   if (length(x$onsets) == 0 || (length(x$onsets) == 1 && is.na(x$onsets[1]))) {

--- a/tests/testthat/test_regressor.R
+++ b/tests/testthat/test_regressor.R
@@ -66,6 +66,17 @@ test_that("shift.Reg shifts onsets correctly", {
   expect_identical(shifted$amplitude, reg$amplitude)
 })
 
+test_that("shift.Reg accepts offset argument", {
+  reg <- regressor(c(1, 3), hrf = HRF_SPMG1)
+  shifted <- shift(reg, offset = 2)
+  expect_equal(shifted$onsets, c(3, 5))
+})
+
+test_that("shift.Reg errors without shift specification", {
+  reg <- regressor(0, hrf = HRF_SPMG1)
+  expect_error(shift(reg), "shift_amount")
+})
+
 
 test_that("evaluate.Reg computes convolution correctly", {
   reg <- regressor(onsets = c(0, 2), hrf = BOX_HRF, span = 1)


### PR DESCRIPTION
## Summary
- add offset fallback logic to `shift.Reg`
- test error when shift amount unspecified
- test `shift.Reg` offset argument

## Testing
- `R CMD check` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683cd581ca0c832da5ff27a2f0d00846