### PR TITLE
Improve sampling_frame length validation

### DIFF
--- a/R/sampling_frame.R
+++ b/R/sampling_frame.R
@@ -15,8 +15,12 @@ new_sampling_frame <- function(blocklens, TR, start_time, precision) {
 #' A \code{sampling_frame} describes the block structure and temporal sampling of an fMRI paradigm.
 #'
 #' @param blocklens A numeric vector representing the number of scans in each block.
-#' @param TR A numeric value or vector representing the repetition time in seconds (i.e., the spacing between consecutive image acquisitions).
-#' @param start_time A numeric value or vector representing the offset of the first scan of each block (default is \code{TR/2}).
+#' @param TR A numeric value or vector representing the repetition time in seconds
+#'   (i.e., the spacing between consecutive image acquisitions). When a vector is
+#'   provided, its length must be 1 or equal to the number of blocks.
+#' @param start_time A numeric value or vector representing the offset of the first
+#'   scan of each block (default is \code{TR/2}). When a vector is provided, its
+#'   length must be 1 or equal to the number of blocks.
 #' @param precision A numeric value representing the discrete sampling interval used for convolution with the hemodynamic response function (default is 0.1).
 #'
 #' @examples
@@ -32,11 +36,19 @@ new_sampling_frame <- function(blocklens, TR, start_time, precision) {
 sampling_frame <- function(blocklens, TR, start_time = TR / 2, precision = .1)
 {
   # --- recycle & validate ------------------------------------------------
-  # Ensure all vectors have the same length
-  max_len <- max(length(blocklens), length(TR), length(start_time))
-  blocklens <- rep_len(blocklens, max_len)
-  TR <- rep_len(TR, max_len)
-  start_time <- rep_len(start_time, max_len)
+  n_blocks <- length(blocklens)
+
+  # Check that TR and start_time are either length 1 or match n_blocks
+  if (length(TR) != 1L && length(TR) != n_blocks) {
+    stop("TR must have length 1 or match the number of blocks")
+  }
+  if (length(start_time) != 1L && length(start_time) != n_blocks) {
+    stop("start_time must have length 1 or match the number of blocks")
+  }
+
+  # Recycle values to the number of blocks
+  TR <- rep_len(TR, n_blocks)
+  start_time <- rep_len(start_time, n_blocks)
   
   # Validate inputs with proper error messages
   if (!all(blocklens > 0)) {

--- a/man/sampling_frame.Rd
+++ b/man/sampling_frame.Rd
@@ -9,9 +9,9 @@ sampling_frame(blocklens, TR, start_time = TR/2, precision = 0.1)
 \arguments{
 \item{blocklens}{A numeric vector representing the number of scans in each block.}
 
-\item{TR}{A numeric value or vector representing the repetition time in seconds (i.e., the spacing between consecutive image acquisitions).}
+\item{TR}{A numeric value or vector representing the repetition time in seconds (i.e., the spacing between consecutive image acquisitions). If a vector is supplied, it must have length 1 or equal the number of blocks.}
 
-\item{start_time}{A numeric value or vector representing the offset of the first scan of each block (default is \code{TR/2}).}
+\item{start_time}{A numeric value or vector representing the offset of the first scan of each block (default is \code{TR/2}). If a vector is supplied, it must have length 1 or equal the number of blocks.}
 
 \item{precision}{A numeric value representing the discrete sampling interval used for convolution with the hemodynamic response function (default is 0.1).}
 }

--- a/tests/testthat/test_sampling_frame.R
+++ b/tests/testthat/test_sampling_frame.R
@@ -13,12 +13,16 @@ test_that("sampling_frame constructor works correctly", {
   expect_equal(sframe2$TR, c(2, 1.5))
   
   # Test input validation
-  expect_error(sampling_frame(blocklens = c(-1, 100), TR = 2), 
+  expect_error(sampling_frame(blocklens = c(-1, 100), TR = 2),
               "Block lengths must be positive")
-  expect_error(sampling_frame(blocklens = c(100, 100), TR = -1), 
+  expect_error(sampling_frame(blocklens = c(100, 100), TR = -1),
               "TR .* must be positive")
   expect_error(sampling_frame(blocklens = c(100, 100), TR = 2, precision = 3),
               "Precision must be positive and less than")
+  expect_error(sampling_frame(blocklens = c(100, 100), TR = c(2, 2, 2)),
+              "TR must have length 1 or match the number of blocks")
+  expect_error(sampling_frame(blocklens = c(100, 100), start_time = c(0, 0, 0)),
+              "start_time must have length 1 or match the number of blocks")
 })
 
 test_that("samples.sampling_frame works correctly", {


### PR DESCRIPTION
## Summary
- enforce length consistency for TR and start_time
- document new length requirements
- test new error conditions for mismatched lengths

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cd5909c50832d8933a2df26c25557