### PR TITLE
Clarify how to access block IDs

### DIFF
--- a/R/sampling_frame.R
+++ b/R/sampling_frame.R
@@ -27,6 +27,9 @@ new_sampling_frame <- function(blocklens, TR, start_time, precision) {
 #' # The global time (with respect to the first block) of each sample/acquisition
 #' gsam <- samples(frame, global = TRUE)
 #'
+#' Block identifiers for each acquisition can be retrieved using
+#' \code{blockids(frame)}.
+#'
 #' @return A list with class "sampling_frame" describing the block structure and temporal sampling of an fMRI paradigm.
 #' @export
 sampling_frame <- function(blocklens, TR, start_time = TR / 2, precision = .1)

--- a/man/sampling_frame.Rd
+++ b/man/sampling_frame.Rd
@@ -29,4 +29,7 @@ sam <- samples(frame)
 # The global time (with respect to the first block) of each sample/acquisition
 gsam <- samples(frame, global = TRUE)
 
+Block identifiers for each acquisition can be retrieved with
+\code{blockids(frame)}.
+
 }

--- a/tests/testthat/test_sampling_frame.R
+++ b/tests/testthat/test_sampling_frame.R
@@ -98,7 +98,7 @@ test_that("sampling_frame maintains temporal consistency", {
   
   # Check uniform spacing within blocks
   for (block in 1:3) {
-    block_idx <- which(sframe$blockids == block)
+    block_idx <- which(blockids(sframe) == block)
     diffs <- diff(glob_samples[block_idx])
     expect_true(all(abs(diffs - 2) < 1e-10))
   }


### PR DESCRIPTION
## Summary
- document how to retrieve block identifiers for each acquisition
- mention `blockids(frame)` in documentation
- use `blockids()` in sampling frame tests

## Testing
- `R --version` *(fails: command not found)*
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cd591e65c832d964f97700c499178