### PR TITLE
Validate blockids input for global_onsets

### DIFF
--- a/R/sampling_frame.R
+++ b/R/sampling_frame.R
@@ -92,12 +92,17 @@ samples.sampling_frame <- function(x, blockids = NULL, global = FALSE,...) {
 
 #' @method global_onsets sampling_frame
 #' @rdname global_onsets
+#' @param blockids Integer vector identifying the block for each onset. Values
+#'   must be whole numbers with no NAs.
 #' @export
 global_onsets.sampling_frame <- function(x, onsets, blockids,...) {
   # Calculate cumulative time offsets for each block
   block_durations <- x$blocklens * x$TR
   cumulative_time <- c(0, cumsum(block_durations))
-  
+
+  if (!is.numeric(blockids) || anyNA(blockids) || any(blockids %% 1 != 0)) {
+    stop("blockids must be whole numbers and not NA")
+  }
   blockids <- as.integer(blockids)
   stopifnot(length(onsets) == length(blockids),
             all(blockids >= 1L), all(blockids <= length(x$blocklens)))

--- a/tests/testthat/test_sampling_frame.R
+++ b/tests/testthat/test_sampling_frame.R
@@ -54,11 +54,11 @@ test_that("global_onsets works correctly", {
   expect_equal(global_times[1], 10)  # First block onset unchanged
   expect_equal(global_times[2], 220)  # Second block onset = 200 (block1 duration) + 20
   
-  # Test error conditions
-  #expect_error(global_onsets(sframe, c(10), c(1, 2)), 
-  #            "length.*onsets.*length.*blockids")
-  #expect_error(global_onsets(sframe, c(10), c(3)), 
-  #            "blockids.*1.*length")
+  # Test error conditions for non-integer block ids
+  expect_error(global_onsets(sframe, onsets, c(1.5, 2)),
+               "blockids must be whole numbers")
+  expect_error(global_onsets(sframe, onsets, c(1, NA)),
+               "blockids must be whole numbers")
 })
 
 test_that("print.sampling_frame works correctly", {


### PR DESCRIPTION
## Summary
- ensure `global_onsets()` checks that `blockids` are whole numbers
- document the new requirement in the method's roxygen comments
- test error handling when fractional or `NA` blockids are provided

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683cd592969c832dba44592785994ca7