### PR TITLE
Add regressor_set class for multi-condition design matrices

### DIFF
--- a/R/regressor-set.R
+++ b/R/regressor-set.R
@@ -1,0 +1,55 @@
+#' Construct a Regressor Set
+#'
+#' Creates a set of regressors, one for each level of a factor. Each
+#' condition shares the same HRF and other parameters but has distinct
+#' onsets, durations and amplitudes.
+#'
+#' @param onsets Numeric vector of event onset times.
+#' @param fac A factor (or object coercible to a factor) indicating the
+#'   condition for each onset.
+#' @param hrf Hemodynamic response function used for all conditions.
+#' @param duration Numeric scalar or vector of event durations.
+#' @param amplitude Numeric scalar or vector of event amplitudes.
+#' @param span Numeric scalar giving the HRF span in seconds.
+#' @param summate Logical; passed to [regressor()].
+#'
+#' @return An object of class `RegSet` containing one `Reg` per factor level.
+#' @export
+regressor_set <- function(onsets, fac, hrf = HRF_SPMG1, duration = 0,
+                          amplitude = 1, span = 40, summate = TRUE) {
+  fac <- as.factor(fac)
+  onsets    <- as.numeric(onsets)
+  duration  <- recycle_or_error(as.numeric(duration), length(onsets), "duration")
+  amplitude <- recycle_or_error(as.numeric(amplitude), length(onsets), "amplitude")
+  if (length(fac) != length(onsets)) {
+    stop("`fac` must be the same length as `onsets`", call. = FALSE)
+  }
+  levs <- levels(fac)
+  regs <- lapply(levs, function(lv) {
+    idx <- which(fac == lv)
+    if (length(idx) == 0) {
+      null_regressor(hrf = hrf, span = span)
+    } else {
+      Reg(onsets = onsets[idx], hrf = hrf,
+          duration = duration[idx], amplitude = amplitude[idx],
+          span = span, summate = summate)
+    }
+  })
+  structure(list(regs = regs, levels = levs), class = c("RegSet", "list"))
+}
+
+#' @rdname regressor_set
+#' @export
+evaluate.RegSet <- function(x, grid, precision = .33,
+                            method = c("conv", "fft", "Rconv", "loop"),
+                            sparse = FALSE, ...) {
+  method <- match.arg(method)
+  mats <- lapply(x$regs, evaluate, grid = grid, precision = precision,
+                 method = method, sparse = FALSE, ...)
+  out <- do.call(cbind, mats)
+  if (sparse) {
+    return(Matrix::Matrix(out, sparse = TRUE))
+  } else {
+    return(out)
+  }
+}

--- a/tests/testthat/test_regressor_set.R
+++ b/tests/testthat/test_regressor_set.R
@@ -1,0 +1,27 @@
+box_hrf_fun <- function(t) ifelse(t >= 0 & t <= 1, 1, 0)
+BOX_HRF <- as_hrf(box_hrf_fun, name = "box", span = 1)
+
+# Basic construction and evaluation
+
+test_that("regressor_set constructs and evaluates", {
+  ons <- c(0, 1, 2, 3)
+  fac <- factor(c("a", "a", "b", "b"))
+  rs <- regressor_set(ons, fac, hrf = BOX_HRF)
+  expect_s3_class(rs, "RegSet")
+  grid <- 0:4
+  mat <- evaluate(rs, grid, method = "conv", precision = 1)
+  expect_true(is.matrix(mat))
+  expect_equal(nrow(mat), length(grid))
+  expect_equal(ncol(mat), nbasis(BOX_HRF) * length(levels(fac)))
+})
+
+# Sparse output
+
+test_that("regressor_set produces sparse matrix", {
+  ons <- c(0, 2)
+  fac <- factor(c("a", "b"))
+  rs <- regressor_set(ons, fac, hrf = BOX_HRF)
+  grid <- 0:4
+  mat <- evaluate(rs, grid, method = "conv", precision = 1, sparse = TRUE)
+  expect_true(inherits(mat, "dgCMatrix"))
+})


### PR DESCRIPTION
## Summary
- add `regressor_set` constructor to create a collection of regressors for each factor level
- implement `evaluate.RegSet` to output one column per HRF basis per condition
- tests for construction, evaluation, and sparse output

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cd9ba62e4832db13cefbed27cfb18