### PR TITLE
Implement regressor_design helper

### DIFF
--- a/R/regressor-design.R
+++ b/R/regressor-design.R
@@ -1,0 +1,57 @@
+#' Build a Design Matrix from Block-wise Onsets
+#'
+#' `regressor_design` extends [regressor_set()] by allowing onsets to be
+#' specified relative to individual blocks and by directly returning the
+#' evaluated design matrix.
+#'
+#' @param onsets Numeric vector of event onset times, expressed relative to the
+#'   start of their corresponding block.
+#' @param fac A factor (or object coercible to a factor) indicating the
+#'   condition for each onset.
+#' @param block Integer vector identifying the block for each onset. Values must
+#'   be valid block indices for `sframe`.
+#' @param sframe A [sampling_frame] describing the temporal structure of the
+#'   experiment.
+#' @param hrf Hemodynamic response function shared by all conditions.
+#' @param duration Numeric scalar or vector of event durations.
+#' @param amplitude Numeric scalar or vector of event amplitudes.
+#' @param span Numeric scalar giving the HRF span in seconds.
+#' @param precision Numeric precision used during convolution.
+#' @param method Evaluation method passed to [evaluate()].
+#' @param sparse Logical; if `TRUE` a sparse design matrix is returned.
+#' @param summate Logical; passed to [regressor()].
+#'
+#' @return A numeric matrix (or sparse matrix) with one column per factor level
+#'   and one row per sample defined by `sframe`.
+#' @export
+regressor_design <- function(onsets, fac, block, sframe,
+                             hrf = HRF_SPMG1, duration = 0,
+                             amplitude = 1, span = 40,
+                             precision = .33,
+                             method = c("conv", "fft", "Rconv", "loop"),
+                             sparse = FALSE,
+                             summate = TRUE) {
+  fac   <- as.factor(fac)
+  block <- as.integer(block)
+
+  if (length(onsets) != length(fac) || length(onsets) != length(block)) {
+    stop("`onsets`, `fac` and `block` must have the same length", call. = FALSE)
+  }
+
+  method <- match.arg(method)
+
+  # Convert block-wise onsets to global timing
+  g_onsets <- global_onsets(sframe, onsets, block)
+
+  # Create regressor set using global onsets
+  rs <- regressor_set(g_onsets, fac, hrf = hrf,
+                      duration = duration, amplitude = amplitude,
+                      span = span, summate = summate)
+
+  # Evaluation grid corresponds to all acquisition times
+  grid <- samples(sframe, global = TRUE)
+
+  evaluate(rs, grid = grid, precision = precision,
+           method = method, sparse = sparse)
+}
+

--- a/tests/testthat/test_regressor_design.R
+++ b/tests/testthat/test_regressor_design.R
@@ -1,0 +1,28 @@
+box_hrf_fun <- function(t) ifelse(t >= 0 & t <= 1, 1, 0)
+BOX_HRF <- as_hrf(box_hrf_fun, name = "box", span = 1)
+
+# Basic construction and evaluation with sampling frame
+
+test_that("regressor_design produces expected design", {
+  ons <- c(0, 1, 0, 2)
+  fac <- factor(c("a", "b", "a", "b"))
+  blk <- c(1L, 1L, 2L, 2L)
+  sf  <- sampling_frame(blocklens = c(3, 3), TR = 1)
+  dmat <- regressor_design(ons, fac, blk, sf, hrf = BOX_HRF, precision = 1)
+  expect_true(is.matrix(dmat))
+  expect_equal(nrow(dmat), length(samples(sf)))
+  expect_equal(ncol(dmat), nbasis(BOX_HRF) * length(levels(fac)))
+})
+
+# Sparse output
+
+test_that("regressor_design returns sparse matrix", {
+  ons <- c(0, 2)
+  fac <- factor(c("a", "b"))
+  blk <- c(1L, 2L)
+  sf  <- sampling_frame(blocklens = c(3, 3), TR = 1)
+  dmat <- regressor_design(ons, fac, blk, sf, hrf = BOX_HRF,
+                           precision = 1, sparse = TRUE)
+  expect_true(inherits(dmat, "dgCMatrix"))
+})
+


### PR DESCRIPTION
## Summary
- add `regressor_design` for block-wise onset design generation
- test design matrix construction

## Testing
- `Rscript -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cdbf56ef4832d84fbfdf04b7bf25c