### PR TITLE
Add LWU HRF and utility tests

### DIFF
--- a/tests/testthat/test_hrf_from_coefficients.R
+++ b/tests/testthat/test_hrf_from_coefficients.R
@@ -1,0 +1,14 @@
+context("hrf_from_coefficients")
+
+test_that("hrf_from_coefficients combines basis correctly", {
+  t <- seq(0, 20, by = 0.5)
+  weights <- c(0.5, 2)
+  h_combined <- hrf_from_coefficients(HRF_SPMG2, weights, name = "combined")
+  expect_s3_class(h_combined, "HRF")
+  expect_equal(nbasis(h_combined), 1L)
+  expect_equal(attr(h_combined, "name"), "combined")
+
+  expected <- as.numeric(HRF_SPMG2(t) %*% weights)
+  result <- h_combined(t)
+  expect_equal(result, expected)
+})

--- a/tests/testthat/test_hrf_lwu_extra.R
+++ b/tests/testthat/test_hrf_lwu_extra.R
@@ -1,0 +1,33 @@
+context("hrf_lwu and related functions")
+
+test_that("hrf_lwu computes response and normalisation", {
+  t <- seq(0, 20, by = 0.5)
+  raw <- hrf_lwu(t, tau = 6, sigma = 2, rho = 0.4)
+  expect_equal(length(raw), length(t))
+  expect_true(is.numeric(raw))
+
+  # height normalisation
+  norm <- hrf_lwu(t, tau = 6, sigma = 2, rho = 0.4, normalize = "height")
+  expect_equal(max(abs(norm)), 1)
+
+  # area normalisation currently behaves like none and warns
+  expect_warning(area <- hrf_lwu(t, tau = 6, sigma = 2, rho = 0.4, normalize = "area"))
+  expect_equal(area, raw)
+})
+
+
+test_that("hrf_basis_lwu returns derivatives", {
+  theta <- c(tau = 6, sigma = 2, rho = 0.4)
+  t <- seq(0, 20, by = 1)
+  basis <- hrf_basis_lwu(theta, t)
+  expect_equal(dim(basis), c(length(t), 4))
+  expect_equal(basis[, "h0"], hrf_lwu(t, tau = theta["tau"], sigma = theta["sigma"], rho = theta["rho"]))
+
+  # finite-difference check of derivative w.r.t tau at one point
+  delta <- 1e-4
+  t0 <- 4
+  fd_tau <- (hrf_lwu(t0, tau = theta["tau"] + delta, sigma = theta["sigma"], rho = theta["rho"]) -
+              hrf_lwu(t0, tau = theta["tau"] - delta, sigma = theta["sigma"], rho = theta["rho"])) / (2 * delta)
+  idx <- which(t == t0)
+  expect_equal(basis[idx, "d_tau"], as.numeric(fd_tau), tolerance = 1e-3)
+})

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -1,0 +1,7 @@
+context("utility functions")
+
+test_that("recycle_or_error recycles or errors correctly", {
+  expect_equal(recycle_or_error(5, 3, "val"), rep(5,3))
+  expect_equal(recycle_or_error(c(1,2,3), 3, "val"), c(1,2,3))
+  expect_error(recycle_or_error(c(1,2), 3, "val"), "length 1 or 3")
+})


### PR DESCRIPTION
## Summary
- add tests for `hrf_lwu` normalization and derivative basis
- add test for combining HRF basis coefficients
- add utility test for `recycle_or_error`

## Testing
- `R -e "library(testthat); test_dir('tests/testthat')"` *(fails: `R` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ce265e70c832db31c2b308719ece2