### PR TITLE
Clean up vignette references

### DIFF
--- a/vignettes/a_01_hemodynamic_response.Rmd
+++ b/vignettes/a_01_hemodynamic_response.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
   message = FALSE,
   warning = FALSE
 )
-library(fmrireg)
+library(fmrihrf)
 library(dplyr) # For pipe operator %>%
 library(ggplot2) # For plotting
 library(tidyr) # For data manipulation
@@ -28,11 +28,11 @@ library(tidyr) # For data manipulation
 
 A hemodynamic response function (HRF) models the temporal evolution of the fMRI BOLD (Blood-Oxygen-Level-Dependent) signal in response to a brief neural event. Typically, the BOLD signal peaks 4-6 seconds after the event onset and then returns to baseline, often with a slight undershoot.
 
-`fmrireg` provides tools to define, manipulate, and visualize various HRFs commonly used in fMRI analysis.
+`fmrihrf` provides tools to define, manipulate, and visualize various HRFs commonly used in fMRI analysis.
 
 ## Pre-defined HRF Objects
 
-`fmrireg` includes several pre-defined HRF objects, which are essentially functions with specific attributes defining their type, number of basis functions (`nbasis`), and effective duration (`span`).
+`fmrihrf` includes several pre-defined HRF objects, which are essentially functions with specific attributes defining their type, number of basis functions (`nbasis`), and effective duration (`span`).
 
 Let's look at two common examples: the SPM canonical HRF (`HRF_SPMG1`) and a Gaussian HRF (`HRF_GAUSSIAN`).
 
@@ -351,7 +351,7 @@ Instead of assuming a fixed HRF shape, we can model the response using a linear 
 
 ### SPM Basis Sets
 
-`fmrireg` provides pre-defined HRF objects for the SPM canonical HRF plus its temporal derivative (`HRF_SPMG2`), and additionally its dispersion derivative (`HRF_SPMG3`).
+`fmrihrf` provides pre-defined HRF objects for the SPM canonical HRF plus its temporal derivative (`HRF_SPMG2`), and additionally its dispersion derivative (`HRF_SPMG3`).
 
 ```{r spm_basis_sets}
 # SPM + Temporal Derivative (2 basis functions)

--- a/vignettes/a_02_regressor.Rmd
+++ b/vignettes/a_02_regressor.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
   message = FALSE,
   warning = FALSE
 )
-library(fmrireg)
+library(fmrihrf)
 library(dplyr)
 library(ggplot2)
 library(tidyr)
@@ -28,7 +28,7 @@ library(tidyr)
 
 In fMRI analysis, a **regressor** (or predictor) represents the expected BOLD signal timecourse associated with a specific experimental condition or event type. It's typically created by convolving a series of event onsets (often represented as delta functions or "sticks") with a hemodynamic response function (HRF).
 
-`fmrireg` provides the `regressor()` function to easily create these objects from event timings and an HRF. While these regressor objects are often constructed automatically behind the scenes by modeling functions like `fmri_lm`, this vignette explores how to create and manipulate them directly, offering finer control over the model components.
+`fmrihrf` provides the `regressor()` function to easily create these objects from event timings and an HRF. While these regressor objects are often constructed automatically by modeling functions in other packages, this vignette explores how to create and manipulate them directly, offering finer control over the model components.
 
 ## Basic Regressor from Event Onsets
 
@@ -72,13 +72,7 @@ ggplot(plot_df, aes(x = Time, y = Response)) +
        x = "Time (seconds)",
        y = "Predicted Response") +
   theme_minimal()
-
-# The autoplot() method provides a quick ggplot object
-# library(ggplot2)
-# autoplot(reg1, grid = scan_times)
 ```
-
-The `autoplot()` method (requires `ggplot2`) provides a quick way to visualize the evaluated timecourse.
 
 ## Varying Event Durations
 
@@ -210,9 +204,6 @@ nbasis(reg_basis) # Should be 5
 scan_times_basis <- seq(0, max(onsets_basis) + 30, by = TR)
 pred_basis_matrix <- evaluate(reg_basis, scan_times_basis)
 dim(pred_basis_matrix) # rows = time points, cols = basis functions
-
-# Plot the basis set regressors using autoplot
-# autoplot(reg_basis, grid = scan_times_basis)
 
 # Or plot manually with ggplot
 colnames(pred_basis_matrix) <- paste0("Basis_", 1:ncol(pred_basis_matrix))

--- a/vignettes/a_03_hrf_generators.Rmd
+++ b/vignettes/a_03_hrf_generators.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
   message = FALSE,
   warning = FALSE
 )
-library(fmrireg)
+library(fmrihrf)
 library(ggplot2)
 library(dplyr)
 library(tidyr)
@@ -26,7 +26,7 @@ library(tidyr)
 
 ## Why Generators?
 
-Most pre-defined HRFs in `fmrireg` (like `HRF_SPMG1` or `HRF_GAUSSIAN`) are ready-to-use objects.  
+Most pre-defined HRFs in `fmrihrf` (like `HRF_SPMG1` or `HRF_GAUSSIAN`) are ready-to-use objects.
 However, some HRFs are actually *generators*. A generator is a function that
 creates a new HRF object when you call it. This allows you to specify the number
 of basis functions (`nbasis`) and the time span (`span`) at creation time.


### PR DESCRIPTION
## Summary
- update vignettes to load `fmrihrf`
- remove references to `fmrireg` and other deprecated functions

## Testing
- `R CMD build .` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ce3d644cc832dac6cad5264054387