### PR TITLE
Add viridis optional dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Suggests:
     ggplot2,
     dplyr,
     tidyr,
+    viridis,
     scales
 VignetteBuilder: knitr
 URL: https://bbuchsbaum.github.io/fmrihrf/

--- a/vignettes/a_04_advanced_modeling.Rmd
+++ b/vignettes/a_04_advanced_modeling.Rmd
@@ -23,7 +23,11 @@ library(dplyr)
 library(ggplot2)
 library(tidyr)
 library(Matrix)
-library(viridis)
+if (requireNamespace("viridis", quietly = TRUE)) {
+  library(viridis)
+} else {
+  scale_color_viridis_d <- function(...) ggplot2::scale_color_brewer(palette = "Set1")
+}
 ```
 
 ## Introduction


### PR DESCRIPTION
## Summary
- add **viridis** to Suggests
- load viridis conditionally in the advanced modeling vignette to avoid build failures

## Testing
- `R CMD build .` *(fails: `R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684425d7c078832d97bfe206fb40bbd5