### PR TITLE
refactor: extract shared single/multi-basis helpers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# fmrihrf (development version)
+
+## Improvements
+
+* Factored the duplicated single-basis / multi-basis branching in
+  `block_hrf()`, `evaluate.HRF()`, and `normalise_hrf()` into three internal
+  helpers (`.weighted_combine`, `.normalise_result`, `.get_peaks`). No
+  user-visible behavior change.
+
 # fmrihrf 0.3.1
 
 ## New Features

--- a/R/hrf.R
+++ b/R/hrf.R
@@ -1113,57 +1113,16 @@ evaluate.HRF <- function(x, grid, amplitude = 1, duration = 0,
 
   # Evaluate based on duration
   out <- if (duration < precision) {
-      # Point evaluation
+    # Point evaluation
     base(grid)
   } else {
-      # Block evaluation
+    # Block evaluation
     quad <- .block_offsets_weights(duration, precision)
-    offs <- quad$offsets
-    weights <- quad$weights
-      # Evaluate HRF at shifted time points for each offset
-      # Use lapply to handle potential matrix output from multi-basis HRFs
-      hlist <- lapply(offs, function(o) base(grid - o))
-      
-      # Check if the result for the first offset is a matrix (multi-basis)
-      is_multi_basis <- is.matrix(hlist[[1]])
-      
-      if (is_multi_basis) {
-          weighted <- Map(function(vals, wt) vals * wt, hlist, weights)
-          res <- Reduce("+", weighted)
-          if (!summate) {
-            weight_sum <- sum(weights)
-            if (weight_sum > 0) {
-              res <- res / weight_sum
-            }
-          }
-          res
-      } else {
-          # Single basis HRF: hlist contains vectors, bind them into a matrix
-        hmat <- do.call(cbind, hlist)
-          res <- as.vector(hmat %*% weights)
-          if (!summate) {
-            weight_sum <- sum(weights)
-            if (weight_sum > 0) {
-              res <- res / weight_sum
-            }
-          }
-          res
-      }
+    hlist <- lapply(quad$offsets, function(o) base(grid - o))
+    .weighted_combine(hlist, quad$weights, summate = summate)
   }
 
-  # Apply normalization if requested, handling matrix/vector case
-  if (normalize) {
-      if (is.matrix(out)) {
-          peaks <- apply(out, 2, function(col) max(abs(col), na.rm = TRUE))
-          peaks[peaks == 0 | is.na(peaks)] <- 1
-          out <- sweep(out, 2, peaks, "/")
-      } else {
-          peak_val <- max(abs(out), na.rm = TRUE)
-          if (!is.na(peak_val) && peak_val != 0) out / peak_val else out
-      }
-  } else {
-    out
-  }
+  if (normalize) .normalise_result(out) else out
 }
 
 #' Plot an HRF Object

--- a/R/hrf_decorators.R
+++ b/R/hrf_decorators.R
@@ -97,55 +97,16 @@ block_hrf <- function(hrf, width, precision = 0.1, half_life = Inf, summate = TR
       res <- hrf(t)
     } else {
       quad <- .block_offsets_weights(width, precision)
-      samples <- quad$offsets
-      weights <- quad$weights
-
-      hmat_list <- lapply(samples, function(offset) {
+      hmat_list <- lapply(quad$offsets, function(offset) {
         decay_factor <- if (is.infinite(half_life)) 1 else exp(-log(2) * offset / half_life)
         hrf(t - offset) * decay_factor
       })
-      
-      # Combine results for each time point t across offsets
-      if (orig_nbasis == 1) {
-        hmat <- do.call(cbind, hmat_list) # Matrix with rows=time, cols=offsets
-        res <- as.vector(hmat %*% weights)
-        if (!summate) {
-          # Same convolution shape but amplitude doesn't grow with duration
-          weight_sum <- sum(weights)
-          if (weight_sum > 0) {
-            res <- res / weight_sum
-          }
-        }
-      } else {
-         weighted_list <- Map(function(vals, wt) vals * wt, hmat_list, weights)
-         res <- Reduce("+", weighted_list)
-         if (!summate) {
-           weight_sum <- sum(weights)
-           if (weight_sum > 0) {
-             res <- res / weight_sum
-           }
-         }
-      }
+      res <- .weighted_combine(hmat_list, quad$weights,
+                                nbasis = orig_nbasis, summate = summate)
     }
-    
-    # Apply normalization if requested
+
     if (normalize) {
-      if (orig_nbasis == 1) {
-        peak_val <- max(abs(res), na.rm = TRUE)
-        if (!is.na(peak_val) && peak_val != 0) {
-          res <- res / peak_val
-        }
-      } else {
-        # Normalize each basis column independently
-        res <- apply(res, 2, function(basis_col) {
-           peak_val <- max(abs(basis_col), na.rm = TRUE)
-           if (!is.na(peak_val) && peak_val != 0) {
-             basis_col / peak_val
-           } else {
-             basis_col
-           }
-        })
-      }
+      res <- .normalise_result(res)
     }
     return(res)
   }
@@ -205,16 +166,12 @@ normalise_hrf <- function(hrf) {
   ref_grid <- seq(0, orig_span, length.out = ref_n)
   ref_vals <- hrf(ref_grid)
 
-  if (orig_nbasis == 1) {
-    peak_val <- max(abs(as.numeric(ref_vals)), na.rm = TRUE)
-    peak_val <- if (is.na(peak_val) || peak_val == 0) 1 else peak_val
+  peak_val <- if (orig_nbasis == 1) {
+    .get_peaks(as.numeric(ref_vals))
   } else if (is.matrix(ref_vals)) {
-    peak_val <- apply(ref_vals, 2, function(basis_col) {
-      max(abs(basis_col), na.rm = TRUE)
-    })
-    peak_val[is.na(peak_val) | peak_val == 0] <- 1
+    .get_peaks(ref_vals)
   } else {
-    peak_val <- 1
+    1
   }
 
   # Create the normalised function

--- a/R/utils-internal.R
+++ b/R/utils-internal.R
@@ -42,3 +42,72 @@ recycle_or_error <- function(x, n, name) {
   }
   list(offsets = offsets, weights = weights)
 }
+
+# Combine a list of HRF evaluations (one per quadrature offset) into a single
+# weighted result. Handles both single-basis (vector) and multi-basis (matrix)
+# outputs uniformly. When `summate = FALSE`, the result is divided by the sum
+# of weights so amplitude does not scale with block width.
+#
+# @param value_list list of numeric vectors (single-basis) or matrices
+#   (multi-basis). All elements must share the same shape.
+# @param weights numeric vector of quadrature weights, same length as value_list.
+# @param nbasis optional declared number of basis functions. When supplied and
+#   equal to 1, the result is flattened to a numeric vector (matching the
+#   original single-basis dispatch in block_hrf). When NULL (default), dispatch
+#   is based solely on the shape of value_list[[1]].
+# @param summate logical; if FALSE, divide by sum(weights).
+# @return a numeric vector or matrix matching the shape of value_list[[1]].
+#' @keywords internal
+#' @noRd
+.weighted_combine <- function(value_list, weights, nbasis = NULL, summate = TRUE) {
+  as_vector <- if (!is.null(nbasis)) {
+    isTRUE(nbasis == 1L)
+  } else {
+    !is.matrix(value_list[[1]])
+  }
+  if (as_vector) {
+    hmat <- do.call(cbind, lapply(value_list, as.numeric))
+    res <- as.vector(hmat %*% weights)
+  } else {
+    weighted <- Map(function(vals, wt) vals * wt, value_list, weights)
+    res <- Reduce("+", weighted)
+  }
+  if (!summate) {
+    weight_sum <- sum(weights)
+    if (weight_sum > 0) {
+      res <- res / weight_sum
+    }
+  }
+  res
+}
+
+# Peak-normalise a vector or matrix. For matrices, each column is normalised
+# independently. Columns (or vectors) whose peak absolute value is 0 or NA are
+# returned unchanged.
+#' @keywords internal
+#' @noRd
+.normalise_result <- function(x) {
+  if (is.matrix(x)) {
+    peaks <- apply(x, 2, function(col) max(abs(col), na.rm = TRUE))
+    peaks[is.na(peaks) | peaks == 0] <- 1
+    sweep(x, 2, peaks, "/")
+  } else {
+    peak_val <- max(abs(x), na.rm = TRUE)
+    if (!is.na(peak_val) && peak_val != 0) x / peak_val else x
+  }
+}
+
+# Compute per-basis peak absolute values from a reference evaluation. Zero or
+# NA peaks are replaced with 1 so downstream division is a no-op. Returns a
+# vector of length ncol(x) for matrices, or a scalar for vectors.
+#' @keywords internal
+#' @noRd
+.get_peaks <- function(x) {
+  if (is.matrix(x)) {
+    peaks <- apply(x, 2, function(col) max(abs(col), na.rm = TRUE))
+  } else {
+    peaks <- max(abs(as.numeric(x)), na.rm = TRUE)
+  }
+  peaks[is.na(peaks) | peaks == 0] <- 1
+  peaks
+}


### PR DESCRIPTION
Consolidate the duplicated single-basis (vector) vs multi-basis (matrix)
branching that appeared in block_hrf(), evaluate.HRF(), and
normalise_hrf() into three internal helpers in R/utils-internal.R:

- .weighted_combine() combines a list of HRF evaluations with quadrature
  weights, handling both shapes and the summate=FALSE scaling. Accepts
  an optional nbasis hint so block_hrf() preserves its original
  declared-nbasis-based dispatch (unobservable for contract-honoring
  HRFs, preserved for safety).
- .normalise_result() peak-normalises a vector or matrix column-wise.
- .get_peaks() computes per-basis reference peaks for normalise_hrf(),
  mapping zero/NA peaks to 1 so downstream division is a no-op.

No user-visible behavior change. Purely mechanical extraction to remove
four duplicated branches and make future decorators declarative.

https://claude.ai/code/session_01PR7ZmnMyoSKruEEv7qYbu5